### PR TITLE
Fix Build your own Elixir talk URL

### DIFF
--- a/_data/talks_given.yml
+++ b/_data/talks_given.yml
@@ -6,7 +6,7 @@
     - text: Recording
       url: https://www.youtube.com/watch?v=IONWi9hayEA&index=13&list=PLWbHc_FXPo2ivlIjzcaHS9N_Swe_0hWj0
     - text: Slides
-      url: http://lpil.uk/talk-slides/fashioning-a-faster-feedback-loop/
+      url: http://lpil.uk/talk-slides/build-your-own-elixir/
     - text: Elixir LDN Conference
       url: http://www.elixir.london/
   description: |


### PR DESCRIPTION
Hey! The URL for the talk "Build Your Own Elixir" was going to the talk "Fashioning a Faster Feedback Loop" so I changed it.